### PR TITLE
Implement pokemon list caching after the first pain, so no more re-fetching the list

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  experimental: {
+    // restore scroll position on back/forward navigation (home <-> detail)
+    scrollRestoration: true,
+  },
   images: {
     dangerouslyAllowSVG: true,
     contentDispositionType: 'attachment',

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -18,14 +18,14 @@ export default function Navbar() {
   };
 
   useEffect(() => {
-    let backgroundTransparacyVar = clientWindowHeight / 600;
-
-    if (backgroundTransparacyVar < 0.52) {
-      let paddingVar = 2 - backgroundTransparacyVar * 3;
-      let boxShadowVar = backgroundTransparacyVar * 0.1;
-      setPadding(paddingVar);
-      setBoxShadow(boxShadowVar);
-    }
+    // Clamp at the threshold so the navbar settles on its collapsed values for
+    // any scroll past it — including an instant jump from scroll restoration —
+    // instead of freezing at whatever padding it last had.
+    const backgroundTransparacyVar = Math.min(clientWindowHeight / 600, 0.52);
+    const paddingVar = 2 - backgroundTransparacyVar * 3;
+    const boxShadowVar = backgroundTransparacyVar * 0.1;
+    setPadding(paddingVar);
+    setBoxShadow(boxShadowVar);
   }, [clientWindowHeight]);
 
   return (

--- a/src/context/PokemonListContext.tsx
+++ b/src/context/PokemonListContext.tsx
@@ -1,0 +1,46 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  Dispatch,
+  SetStateAction,
+  ReactNode,
+} from "react";
+import { PokemonData } from "@dex/interfaces/pokemon";
+
+type PokemonListState = {
+  pokemons: PokemonData[];
+  setPokemons: Dispatch<SetStateAction<PokemonData[]>>;
+  page: number;
+  setPage: Dispatch<SetStateAction<number>>;
+  isLast: boolean;
+  setIsLast: Dispatch<SetStateAction<boolean>>;
+};
+
+const PokemonListContext = createContext<PokemonListState | undefined>(
+  undefined,
+);
+
+// Lives in _app.tsx, so the list state survives page navigation (home <-> detail)
+// for the whole client session. A full browser refresh starts fresh.
+export function PokemonListProvider({ children }: { children: ReactNode }) {
+  const [pokemons, setPokemons] = useState<PokemonData[]>([]);
+  const [page, setPage] = useState(0);
+  const [isLast, setIsLast] = useState(false);
+
+  return (
+    <PokemonListContext.Provider
+      value={{ pokemons, setPokemons, page, setPage, isLast, setIsLast }}
+    >
+      {children}
+    </PokemonListContext.Provider>
+  );
+}
+
+export function usePokemonList() {
+  const ctx = useContext(PokemonListContext);
+  if (!ctx) {
+    throw new Error("usePokemonList must be used within a PokemonListProvider");
+  }
+  return ctx;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,14 @@
 import "@dex/styles/globals.css";
 import type { AppProps } from "next/app";
 import Layout from "@dex/components/Layout";
+import { PokemonListProvider } from "@dex/context/PokemonListContext";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <PokemonListProvider>
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </PokemonListProvider>
   );
 }


### PR DESCRIPTION
On this PR adding caching feature to homepage so user doesn't start with the first list anymore after navigating back from detail page. This PR create
- PokemonListContext
- Custom usePokemonList context to cache or save list data in memory
- Improve Navbar dynamic padding. using clamp instead of only checking the first px of the page
- Retain scroll position for the user using experimental next js the router

Caveat, this implementation is in-memory state where the state only save when browsing around and will be reset when full page reload