### PR TITLE
Add Not found page and server Error page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "eslint": "8.38.0",
         "eslint-config-next": "13.3.0",
         "next": "13.3.0",
-        "pokenode-ts": "^1.18.3",
+        "pokenode-ts": "^1.20.0",
         "postcss": "^8.4.22",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint": "8.38.0",
     "eslint-config-next": "13.3.0",
     "next": "13.3.0",
-    "pokenode-ts": "^1.18.3",
+    "pokenode-ts": "^1.20.0",
     "postcss": "^8.4.22",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/lib/pokemon.ts
+++ b/src/lib/pokemon.ts
@@ -36,7 +36,7 @@ function mapPokemon(data: Pokemon): PokemonData {
   return {
     id: data.id,
     name: data.name,
-    image: data.sprites.other?.["official-artwork"].front_default ?? "",
+    image: data.sprites.other?.home.front_default ?? "",
     types: data.types.map((t) => t.type.name),
     stats: data.stats.map((s) => ({ name: s.stat.name, value: s.base_stat })),
     height: data.height,
@@ -264,7 +264,7 @@ export async function getPokemonDetail(
 
   return {
     ...base,
-    shinyImage: pokemon.sprites.other?.["official-artwork"].front_shiny ?? "",
+    shinyImage: pokemon.sprites.other?.home.front_shiny ?? "",
     abilities,
     evolution: flattenChain(chain.chain),
     matchups: computeMatchups(typeData),

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,54 @@
+import Head from "next/head";
+import Link from "next/link";
+import Image from "next/image";
+import { Card } from "@dex/components/Card";
+
+// Pages Router custom 404 — statically generated and auto-rendered for unknown
+// routes and for any page that returns { notFound: true } (e.g. an invalid
+// Pokémon name on /detail/[id]).
+export default function NotFound() {
+  return (
+    <>
+      <Head>
+        <title>404 · Page not found | Nextdex</title>
+      </Head>
+
+      <div className="mx-auto max-w-2xl py-12 sm:py-20">
+        <Card>
+          <div className="flex flex-col items-center gap-5 px-2 py-6 text-center">
+            {/* A confused Psyduck on a glow — the universal "I'm lost" mascot. */}
+            <div className="relative h-40 w-40">
+              <div
+                aria-hidden
+                className="absolute inset-6 rounded-full bg-[#38bdf8] opacity-30 blur-3xl"
+              />
+              <Image
+                src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/54.png"
+                alt="A confused Psyduck"
+                fill
+                sizes="160px"
+                className="object-contain drop-shadow-2xl"
+                placeholder="blur"
+                blurDataURL="/images/placeholder.png"
+              />
+            </div>
+
+            <p className="text-6xl font-black tracking-tight sm:text-7xl">404</p>
+            <h1 className="text-xl font-semibold">Lost in the tall grass</h1>
+            <p className="max-w-md text-sm leading-relaxed text-zinc-400">
+              The page you&rsquo;re looking for fled, evolved, or never existed
+              &mdash; even Psyduck looks confused.
+            </p>
+
+            <Link
+              href="/"
+              className="mt-1 rounded-full border border-white/15 bg-white/5 px-5 py-2.5 text-sm font-medium text-zinc-100 transition hover:border-white/25 hover:bg-white/10"
+            >
+              &larr; Back to the Pokédex
+            </Link>
+          </div>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,0 +1,53 @@
+import Head from "next/head";
+import Link from "next/link";
+import Image from "next/image";
+import { Card } from "@dex/components/Card";
+
+// Pages Router custom 500 — statically generated and shown when the server hits
+// an unexpected error. Mirrors the 404 page's layout.
+export default function ServerError() {
+  return (
+    <>
+      <Head>
+        <title>500 · Something went wrong | Nextdex</title>
+      </Head>
+
+      <div className="mx-auto max-w-2xl py-12 sm:py-20">
+        <Card>
+          <div className="flex flex-col items-center gap-5 px-2 py-6 text-center">
+            {/* Electrode, the Self-Destruct Pokémon — "the server blew up." */}
+            <div className="relative h-40 w-40">
+              <div
+                aria-hidden
+                className="absolute inset-6 rounded-full bg-[#fb7185] opacity-30 blur-3xl"
+              />
+              <Image
+                src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/101.png"
+                alt="Electrode about to self-destruct"
+                fill
+                sizes="160px"
+                className="object-contain drop-shadow-2xl"
+                placeholder="blur"
+                blurDataURL="/images/placeholder.png"
+              />
+            </div>
+
+            <p className="text-6xl font-black tracking-tight sm:text-7xl">500</p>
+            <h1 className="text-xl font-semibold">Something went wrong</h1>
+            <p className="max-w-md text-sm leading-relaxed text-zinc-400">
+              Our server used Self-Destruct &mdash; that&rsquo;s on us, not you.
+              Give it a moment and try again.
+            </p>
+
+            <Link
+              href="/"
+              className="mt-1 rounded-full border border-white/15 bg-white/5 px-5 py-2.5 text-sm font-medium text-zinc-100 transition hover:border-white/25 hover:bg-white/10"
+            >
+              &larr; Back to the Pokédex
+            </Link>
+          </div>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Not found page and server error page are not handled yet. So now we have 404 page and 500 page.
- 404 Page with A confused Psyduck sprite on a soft blue glow (the "I'm lost" mascot) and Big 404, "Lost in the tall grass" heading, and playful copy, and the ← Back to the Pokédex CTA.
- 500 page with Electrode on a warm red "error" glow, big 500, "Something went wrong" + the "Our server used Self-Destruct — that's on us, not you" copy, and the ← Back to the Pokédex CTA.