### PR TITLE
Minor fix for mobile view and ghost number position adjustment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextdex",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextdex",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.13",
         "@types/node": "18.15.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextdex",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/ControlDeck.tsx
+++ b/src/components/ControlDeck.tsx
@@ -20,7 +20,7 @@ export function ControlDeck({
   resultCount,
 }: ControlDeckProps) {
   return (
-    <div className="sticky z-[9] top-[72px] rounded-2xl border border-white/10 bg-slate-950/60 p-3 shadow-lg backdrop-blur-md sm:p-4">
+    <div className="sticky z-[9] top-[72px] rounded-2xl bg-slate-950/60 p-3 shadow-lg backdrop-blur-md sm:p-4">
       <div className="flex gap-2 flex-row items-center">
         <div className="relative flex-1">
           <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -16,7 +16,7 @@ export function Layout({ children }: LayoutProps) {
         <title>Pokemon | Nextdex</title>
       </Head>
       <Navbar />
-      <main className={`${font.className} px-2 md:px-7 lg:px-auto pb-10`}>
+      <main className={`${font.className} px-3 md:px-7 lg:px-auto pb-10`}>
         {children}
       </main>
     </>

--- a/src/components/PokemonRow.tsx
+++ b/src/components/PokemonRow.tsx
@@ -25,19 +25,19 @@ function PokemonRowComponent({ pokemon }: PokemonRowProps) {
           (the type chips sit centered, so they no longer clash with it). */}
       <span
         aria-hidden
-        className="pointer-events-none absolute right-5 top-1/2 z-0 -translate-y-1/2 text-7xl font-black leading-none opacity-[0.07] transition-opacity duration-300 group-hover:opacity-[0.12]"
+        className="pointer-events-none absolute right-4 top-1/2 z-0 -translate-y-1/2 text-7xl font-black leading-none opacity-[0.05] transition-opacity duration-300 group-hover:opacity-[0.10]"
         style={{ color: typeColor }}
       >
         {dex}
       </span>
 
       {/* Sprite on glow halo */}
+      <div
+        aria-hidden
+        className="absolute inset-x-4 w-16 h-16 md:w-20 md:h-20 lg:w-24 lg:h-20 rounded-full opacity-50 blur-xl transition-opacity duration-300 group-hover:opacity-70"
+        style={{ backgroundColor: typeColor }}
+      />
       <div className="relative z-10 h-16 w-16 shrink-0 md:h-20 md:w-20 lg:h-24 lg:w-24">
-        <div
-          aria-hidden
-          className="absolute inset-1 rounded-full opacity-50 blur-xl transition-opacity duration-300 group-hover:opacity-80"
-          style={{ backgroundColor: typeColor }}
-        />
         <Image
           src={pokemon.image}
           alt={pokemon.name}
@@ -83,7 +83,7 @@ export function PokemonRowSkeleton({ id, name }: { id: number; name: string }) {
       {/* Ghost number (untinted until the type is known) */}
       <span
         aria-hidden
-        className="pointer-events-none absolute right-5 top-1/2 -translate-y-1/2 text-7xl font-black leading-none text-white/[0.04]"
+        className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-7xl font-black leading-none text-white/[0.04]"
       >
         {dexNo(id)}
       </span>


### PR DESCRIPTION
There is an issue where when user in mobile scroll or tap the row the glow behind the pokemon art will be chopped.
Move the glow outside the artwork div so the glow div should not be chopped anymore.
Adjust position of ghost number abit to the right