### PR TITLE
Refactor usePokedexBrowser hook to split search and sort to make it cleaner and readable

### DIFF
--- a/src/components/home/ControlDeck.tsx
+++ b/src/components/home/ControlDeck.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent } from "react";
 
-export type SortKey = "number" | "name";
+export type SortKey = "number" | "name" | "reverseNum" | "reverseName";
 
 type ControlDeckProps = {
   query: string;
@@ -53,8 +53,14 @@ export function ControlDeck({
             <option className="bg-slate-900 text-white" value="number">
               Number
             </option>
+            <option className="bg-slate-900 text-white" value="reverseNum">
+              Reverse Number
+            </option>
             <option className="bg-slate-900 text-white" value="name">
               Name (A–Z)
+            </option>
+            <option className="bg-slate-900 text-white" value="reverseName">
+              Name (Z-A)
             </option>
           </select>
         </div>

--- a/src/context/PokemonListContext.tsx
+++ b/src/context/PokemonListContext.tsx
@@ -13,9 +13,11 @@ type PokemonListState = {
   // returning from a detail page doesn't refetch what was already shown.
   details: Record<string, PokemonData>;
   setDetails: Dispatch<SetStateAction<Record<string, PokemonData>>>;
-  // How many entries of the (filtered/sorted) index are currently shown.
-  count: number;
-  setCount: Dispatch<SetStateAction<number>>;
+  // How many entries of the browse list are revealed. Kept here (not in the
+  // browser hook) so the depth — and thus the list you return to when a search
+  // is cleared — survives home↔detail navigation for the whole session.
+  browseCount: number;
+  setBrowseCount: Dispatch<SetStateAction<number>>;
 };
 
 const PokemonListContext = createContext<PokemonListState | undefined>(
@@ -27,11 +29,11 @@ const PokemonListContext = createContext<PokemonListState | undefined>(
 // fresh.
 export function PokemonListProvider({ children }: { children: ReactNode }) {
   const [details, setDetails] = useState<Record<string, PokemonData>>({});
-  const [count, setCount] = useState(0);
+  const [browseCount, setBrowseCount] = useState(0);
 
   return (
     <PokemonListContext.Provider
-      value={{ details, setDetails, count, setCount }}
+      value={{ details, setDetails, browseCount, setBrowseCount }}
     >
       {children}
     </PokemonListContext.Provider>

--- a/src/hooks/useLazyDetails.ts
+++ b/src/hooks/useLazyDetails.ts
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useState } from "react";
+import { PokemonData } from "@dex/interfaces/pokemon";
+import { usePokemonList } from "@dex/context/PokemonListContext";
+
+// The index only carries id+name, so each visible row's full PokemonData is
+// fetched on demand. We fetch at most this many per pass, so revealing a deep
+// window (or re-sorting) fills progressively instead of firing hundreds of
+// requests at once; later passes pick up the rest as the cache fills.
+const FETCH_BATCH = 18;
+
+async function fetchPokemon(name: string): Promise<PokemonData | null> {
+  const res = await fetch(`/api/pokemon/${name}`);
+  if (!res.ok) return null; // leave the row missing; a later pass retries it
+  const { data } = await res.json();
+  return data as PokemonData;
+}
+
+// Fold freshly fetched details into the cache, skipping failures (null) and
+// names already present. Returns the SAME object when nothing new arrived, so a
+// batch of all-failed fetches can't spin the loading effect into a retry loop.
+function mergeFetched(
+  cache: Record<string, PokemonData>,
+  fetched: (PokemonData | null)[],
+): Record<string, PokemonData> {
+  let changed = false;
+  const next = { ...cache };
+  for (const p of fetched) {
+    if (p && !next[p.name]) {
+      next[p.name] = p;
+      changed = true;
+    }
+  }
+  return changed ? next : cache;
+}
+
+// Ensures the given names have their PokemonData loaded, fetching any misses in
+// capped batches. `seed` (the SSG first page) is merged over the shared cache
+// so those rows never refetch. Returns the lookup + whether a fetch is in
+// flight (so the list can hold off growing until the current batch lands).
+export function useLazyDetails(names: string[], seed: PokemonData[]) {
+  const { details, setDetails } = usePokemonList();
+  const [isFetching, setIsFetching] = useState(false);
+
+  // Everything renderable: the seeded first page over the lazily-loaded cache.
+  const byName = useMemo(() => {
+    const map: Record<string, PokemonData> = {};
+    seed.forEach((p) => (map[p.name] = p));
+    return { ...map, ...details };
+  }, [seed, details]);
+
+  useEffect(() => {
+    const missing = names.filter((name) => !byName[name]).slice(0, FETCH_BATCH);
+    if (missing.length === 0) {
+      setIsFetching(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsFetching(true);
+    (async () => {
+      const fetched = await Promise.all(missing.map(fetchPokemon));
+      if (cancelled) return;
+      setDetails((cache) => mergeFetched(cache, fetched));
+      setIsFetching(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [names, byName, setDetails]);
+
+  return { byName, isFetching };
+}

--- a/src/hooks/usePokedexBrowser.ts
+++ b/src/hooks/usePokedexBrowser.ts
@@ -1,11 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { PokemonData } from "@dex/interfaces/pokemon";
 import { PokemonIndexEntry } from "@dex/lib/pokemon";
 import { usePokemonList } from "@dex/context/PokemonListContext";
 import { useDebouncedValue } from "@dex/hooks/useDebouncedValue";
+import { useLazyDetails } from "@dex/hooks/useLazyDetails";
 import { dexNo } from "@dex/constant/pokemonMeta";
 import { SortKey } from "@dex/components/home/ControlDeck";
 
+// One "page": the reveal step for infinite scroll and the SSG first-page size.
 export const PAGE_LIMIT = 18;
 
 type UsePokedexBrowserArgs = {
@@ -13,145 +15,108 @@ type UsePokedexBrowserArgs = {
   index: PokemonIndexEntry[];
 };
 
-// The Nextdex "browser engine": search + sort over the full-dex index, with
-// the row list windowed and its details lazy-loaded as you scroll. The model is
-// simply "ensure the visible window's details are loaded, then render the
-// loaded ones" — so re-sorting just loads whatever the new window needs, and a
-// failed fetch leaves a row missing (retried later) rather than skipped.
+// A query matches an entry on its name or its zero-padded dex number, both as
+// case-insensitive substrings — so "char", "25" and "025" all find their mon.
+function matchesQuery(entry: PokemonIndexEntry, query: string): boolean {
+  return entry.name.includes(query) || dexNo(entry.id).includes(query);
+}
+
+// How each sort key orders the dex. Offering a new ordering is a two-line
+// change: add a comparator here and a matching <option> in ControlDeck.
+type Comparator = (a: PokemonIndexEntry, b: PokemonIndexEntry) => number;
+const SORT_COMPARATORS: Record<SortKey, Comparator> = {
+  number: (a, b) => a.id - b.id,
+  name: (a, b) => a.name.localeCompare(b.name),
+  reverseNum: (a, b) => b.id - a.id,
+  reverseName: (a, b) => b.name.localeCompare(a.name),
+};
+
+// The Nextdex "browser engine". It owns one idea: take the full id+name index,
+// filter + sort it, then reveal a growing window whose row details are lazily
+// loaded. Browsing and searching keep separate reveal depths, so clearing the
+// search drops you straight back onto the browse list, right where you left it.
 export function usePokedexBrowser({ results, index }: UsePokedexBrowserArgs) {
-  const { details, setDetails, count, setCount } = usePokemonList();
+  const { browseCount, setBrowseCount } = usePokemonList();
   const [query, setQuery] = useState("");
   const [sort, setSort] = useState<SortKey>("number");
-  const [searchCount, setSearchCount] = useState(PAGE_LIMIT);
-  const [isIntersecting, setIsIntersecting] = useState(false);
-  const [isFetching, setIsFetching] = useState(false);
+
   const debouncedQuery = useDebouncedValue(query, 250);
-  const searchActive = debouncedQuery.trim() !== "";
+  const search = debouncedQuery.trim().toLowerCase();
+  const isSearching = search !== "";
 
-  // Everything we can render: the SSG first page merged with anything fetched on
-  // scroll. Merging `results` means the first page never needs refetching.
-  const detailsByName = useMemo(() => {
-    const map: Record<string, PokemonData> = {};
-    results.forEach((p) => (map[p.name] = p));
-    return { ...map, ...details };
-  }, [results, details]);
-
-  // The whole dex, filtered by the query and sorted.
-  const orderedIndex = useMemo(() => {
-    const q = debouncedQuery.trim().toLowerCase();
-    const matched = q
-      ? index.filter(
-          (e) => e.name.includes(q) || dexNo(e.id).includes(q),
-        )
+  // Filter + sort the whole dex. It's only id+name, so re-running this over all
+  // ~1300 entries on each keystroke is cheap.
+  const matches = useMemo(() => {
+    const filtered = isSearching
+      ? index.filter((entry) => matchesQuery(entry, search))
       : index;
-    return [...matched].sort((a, b) =>
-      sort === "name" ? a.name.localeCompare(b.name) : a.id - b.id,
-    );
-  }, [index, debouncedQuery, sort]);
+    return [...filtered].sort(SORT_COMPARATORS[sort]);
+  }, [index, search, isSearching, sort]);
 
-  // How many entries to show. Browse depth lives in context (so it survives
-  // home↔detail navigation); search gets its own window, so clearing the query
-  // restores the browse depth.
-  const visibleCount = searchActive ? searchCount : Math.max(count, PAGE_LIMIT);
-  const visibleEntries = useMemo(
-    () => orderedIndex.slice(0, visibleCount),
-    [orderedIndex, visibleCount],
+  // Reveal depth. Browsing persists in context (survives navigation and a
+  // search-and-clear); searching uses its own window that resets per new query.
+  const [searchCount, setSearchCount] = useState(PAGE_LIMIT);
+  useEffect(() => setSearchCount(PAGE_LIMIT), [search]);
+
+  const browseReveal = Math.max(browseCount, PAGE_LIMIT); // context starts at 0
+  const revealCount = isSearching ? searchCount : browseReveal;
+
+  const visible = useMemo(
+    () => matches.slice(0, revealCount),
+    [matches, revealCount],
   );
-  const isLast = visibleCount >= orderedIndex.length;
+  const isLast = revealCount >= matches.length;
 
-  // A new query restarts the search window (the browse window is left alone).
-  useEffect(() => {
-    setSearchCount(PAGE_LIMIT);
-  }, [debouncedQuery]);
+  // Ensure the visible rows' details are loaded; rows render a skeleton until
+  // their fetch lands.
+  const visibleNames = useMemo(() => visible.map((e) => e.name), [visible]);
+  const { byName, isFetching } = useLazyDetails(visibleNames, results);
 
-  // Changing the sort re-orders the whole list, so collapse both windows back to
-  // one page (otherwise a carried-over depth would re-fetch hundreds of rows in
-  // the new order). Ref-guarded so it skips mount and keeps a restored depth on
-  // back-navigation.
-  const prevSort = useRef(sort);
-  useEffect(() => {
-    if (prevSort.current === sort) return;
-    prevSort.current = sort;
-    setCount(PAGE_LIMIT);
+  // Re-sorting reorders the whole list, so reset both reveal windows to one page
+  // and jump to the top — otherwise a deep carried-over depth would lazy-load
+  // hundreds of rows in the new order. Done here on the user's pick (not in an
+  // effect watching `sort`), so it skips mount and leaves a depth restored by
+  // back-navigation untouched, and the reset lands in the same render as the
+  // new order (no transient deep window).
+  function changeSort(next: SortKey) {
+    if (next === sort) return;
+    setSort(next);
+    setBrowseCount(PAGE_LIMIT);
     setSearchCount(PAGE_LIMIT);
     window.scrollTo({ top: 0, behavior: "smooth" });
-  }, [sort, setCount]);
+  }
 
-  // Load details for visible rows we don't have yet (capped per pass so a deep
-  // re-sort fills progressively instead of firing hundreds of requests at once).
+  // Infinite scroll: VirtualScroll flips this true when the sentinel enters
+  // view. We reveal exactly one more page and consume the flag, so a sentinel
+  // sitting in view can't run through page after page — it re-fires only on a
+  // fresh entry, never while a batch is still loading or once we're at the end.
+  const [atSentinel, setAtSentinel] = useState(false);
   useEffect(() => {
-    const missing = visibleEntries
-      .filter((e) => !detailsByName[e.name])
-      .map((e) => e.name)
-      .slice(0, PAGE_LIMIT);
-    if (missing.length === 0) {
-      setIsFetching(false);
-      return;
-    }
+    if (!atSentinel || isFetching || isLast) return;
+    setAtSentinel(false);
+    if (isSearching) setSearchCount((c) => c + PAGE_LIMIT);
+    else setBrowseCount((c) => Math.max(c, PAGE_LIMIT) + PAGE_LIMIT);
+  }, [atSentinel, isFetching, isLast, isSearching, setBrowseCount]);
 
-    let cancelled = false;
-    setIsFetching(true);
-    (async () => {
-      const fetched = await Promise.all(
-        missing.map(async (name) => {
-          const resp = await fetch(`/api/pokemon/${name}`);
-          if (!resp.ok) return null;
-          const { data } = await resp.json();
-          return data as PokemonData;
-        }),
-      );
-      if (cancelled) return;
-      setDetails((prev) => {
-        let changed = false;
-        const next = { ...prev };
-        fetched.forEach((p) => {
-          if (p && !next[p.name]) {
-            next[p.name] = p;
-            changed = true;
-          }
-        });
-        return changed ? next : prev; // same ref when nothing new → no retry loop
-      });
-      setIsFetching(false);
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [visibleEntries, detailsByName, setDetails]);
-
-  // Reveal exactly one more page per intersection: consume the flag so the
-  // window doesn't keep growing while the sentinel sits in view (which would
-  // load many batches at once). It re-fires when the sentinel re-enters.
-  useEffect(() => {
-    if (!isIntersecting || isFetching || isLast) return;
-    setIsIntersecting(false);
-    if (searchActive) setSearchCount((c) => c + PAGE_LIMIT);
-    else setCount((c) => Math.max(c, PAGE_LIMIT) + PAGE_LIMIT);
-  }, [isIntersecting, isFetching, isLast, searchActive, setCount]);
-
-  // Every visible row, with its details if loaded yet (null → render a skeleton
-  // while it loads). The window only grows a page at a time, so the pending rows
-  // are the batch currently being fetched.
   const rows = useMemo(
     () =>
-      visibleEntries.map((e) => ({
-        id: e.id,
-        name: e.name,
-        data: detailsByName[e.name] ?? null,
+      visible.map((entry) => ({
+        id: entry.id,
+        name: entry.name,
+        data: byName[entry.name] ?? null,
       })),
-    [visibleEntries, detailsByName],
+    [visible, byName],
   );
 
   return {
     query,
     setQuery,
     sort,
-    setSort,
+    setSort: changeSort,
     rows,
-    resultCount: orderedIndex.length,
+    resultCount: matches.length,
     isLast,
-    isEmpty: orderedIndex.length === 0,
-    onIntersect: setIsIntersecting,
+    isEmpty: matches.length === 0,
+    onIntersect: setAtSentinel,
   };
 }


### PR DESCRIPTION
Refactoring usePokedexBrowser hook, previously it's so convoluted that makes following the code hard. With this seperate searching in useLazyDetails hook and sort still in usePokedexBrowser.
Sort also changes from useRef to observe the sort value into event base using function changeSort();
Sort also now using Sort Comparator, make it easier when adding more sort key into the component