### PR TITLE
Removing on push detection strategy to github workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ name: "CodeQL Analysis"
 
 on:
   push:
-    branches: ["main", "staging"]
+    branches: ["main"]
   pull_request:
     branches: ["main", "staging"]
   schedule:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -11,7 +11,7 @@ name: ESLint
 
 on:
   push:
-    branches: [ "main", "staging" ]
+    branches: [ "main" ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main", "staging" ]


### PR DESCRIPTION
On second though no need for push check on staging branch as this branch only main branch push strategy. But creating PR to staging still check CodeQL and ESLint