### PR TITLE
Implement muted secondary color to all page and component

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -43,7 +43,7 @@ export default function Error({
 
           <p className="text-6xl font-black tracking-tight sm:text-7xl">500</p>
           <h1 className="text-xl font-semibold">Something went wrong</h1>
-          <p className="max-w-md text-sm leading-relaxed text-zinc-400">
+          <p className="max-w-md text-sm leading-relaxed text-ink-muted">
             Our server used Self-Destruct &mdash; that&rsquo;s on us, not you.
             Give it a moment and try again.
           </p>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -33,7 +33,7 @@ export default function NotFound() {
 
           <p className="text-6xl font-black tracking-tight sm:text-7xl">404</p>
           <h1 className="text-xl font-semibold">Lost in the tall grass</h1>
-          <p className="max-w-md text-sm leading-relaxed text-zinc-400">
+          <p className="max-w-md text-sm leading-relaxed text-ink-muted">
             The page you&rsquo;re looking for fled, evolved, or never existed
             &mdash; even Psyduck looks confused.
           </p>

--- a/src/components/abilities/AbilityBrowser.tsx
+++ b/src/components/abilities/AbilityBrowser.tsx
@@ -57,7 +57,7 @@ export function AbilityBrowser({ initial }: AbilityBrowserProps) {
       </div>
 
       {isEmpty && (
-        <p className="py-8 text-center text-zinc-500">
+        <p className="py-8 text-center text-ink-muted">
           {query ? `No abilities match "${query}".` : "Nothing to show."}
         </p>
       )}

--- a/src/components/abilities/AbilityHero.tsx
+++ b/src/components/abilities/AbilityHero.tsx
@@ -4,7 +4,7 @@ import { genShortLabel } from "@constant/pokemonMeta";
 export function AbilityHero({ ability }: { ability: AbilityData }) {
   return (
     <header className="pt-6 text-center">
-      <p className="text-xs font-semibold uppercase tracking-[0.3em] text-zinc-500">
+      <p className="text-xs font-semibold uppercase tracking-[0.3em] text-ink-muted">
         Ability
       </p>
       <h1 className="mt-2 text-4xl font-black capitalize tracking-tight sm:text-5xl">

--- a/src/components/abilities/AbilityPokemonGrid.tsx
+++ b/src/components/abilities/AbilityPokemonGrid.tsx
@@ -38,8 +38,8 @@ function Group({
   if (pokemon.length === 0) return null;
   return (
     <div>
-      <h3 className="mb-3 text-sm font-semibold text-zinc-400">
-        {title} <span className="text-zinc-600">({pokemon.length})</span>
+      <h3 className="mb-3 text-sm font-semibold text-ink-muted">
+        {title} <span className="text-ink-muted">({pokemon.length})</span>
       </h3>
       <div className="grid grid-cols-3 gap-2 sm:grid-cols-4 md:grid-cols-6">
         {pokemon.map((p) => (
@@ -57,7 +57,7 @@ export function AbilityPokemonGrid({
 }) {
   if (pokemon.length === 0) {
     return (
-      <p className="text-sm text-zinc-500">No Pokémon have this ability.</p>
+      <p className="text-sm text-ink-muted">No Pokémon have this ability.</p>
     );
   }
 

--- a/src/components/abilities/AbilityRow.tsx
+++ b/src/components/abilities/AbilityRow.tsx
@@ -28,13 +28,13 @@ function AbilityRowComponent({ ability }: AbilityRowProps) {
       </div>
 
       <div className="z-10 flex min-w-0 flex-1 flex-col gap-1">
-        <span className="text-xs font-medium tracking-[0.2em] text-zinc-500">
+        <span className="text-xs font-medium tracking-[0.2em] text-ink-muted">
           {genShortLabel(ability.generation)}
         </span>
         <h2 className="truncate text-lg font-semibold capitalize tracking-tight">
           {displayName}
         </h2>
-        <p className="line-clamp-2 text-xs text-zinc-400">{ability.effect}</p>
+        <p className="line-clamp-2 text-xs text-ink-muted">{ability.effect}</p>
       </div>
     </Link>
   );
@@ -67,7 +67,7 @@ export function AbilityRowSkeleton({
       <div className="z-10 flex min-w-0 flex-1 flex-col gap-1">
         <span className="h-3 w-14 animate-pulse rounded bg-white/10" />
         {name ? (
-          <h2 className="truncate text-lg font-semibold capitalize tracking-tight text-zinc-400">
+          <h2 className="truncate text-lg font-semibold capitalize tracking-tight text-ink-muted">
             {name.replace(/-/g, " ")}
           </h2>
         ) : (

--- a/src/components/detail/AbilityList.tsx
+++ b/src/components/detail/AbilityList.tsx
@@ -20,7 +20,7 @@ export function AbilityList({ abilities }: { abilities: AbilityInfo[] }) {
               </span>
             )}
           </div>
-          <p className="text-sm leading-relaxed text-zinc-400">
+          <p className="text-sm leading-relaxed text-ink-muted">
             {ability.effect || "No description available."}
           </p>
         </Link>

--- a/src/components/detail/AboutPanel.tsx
+++ b/src/components/detail/AboutPanel.tsx
@@ -12,7 +12,7 @@ type AboutPanelProps = {
 function Row({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-col gap-0.5 border-b border-white/5 py-2 sm:flex-row sm:items-center sm:justify-between">
-      <dt className="text-sm text-zinc-500">{label}</dt>
+      <dt className="text-sm text-ink-muted">{label}</dt>
       <dd className="text-sm font-medium capitalize text-zinc-200">
         {children}
       </dd>
@@ -35,13 +35,13 @@ export function AboutPanel({ species, height, weight }: AboutPanelProps) {
         <Row label="Growth rate">{species.growthRate.replace(/-/g, " ")}</Row>
         <Row label="Catch rate">
           {species.captureRate}{" "}
-          <span className="text-zinc-500">
+          <span className="text-ink-muted">
             ({pct255(species.captureRate)}%)
           </span>
         </Row>
         <Row label="Base happiness">
           {species.baseHappiness}{" "}
-          <span className="text-zinc-500">
+          <span className="text-ink-muted">
             ({pct255(species.baseHappiness)}%)
           </span>
         </Row>

--- a/src/components/detail/DetailHero.tsx
+++ b/src/components/detail/DetailHero.tsx
@@ -54,16 +54,16 @@ export function DetailHero({ pokemon }: DetailHeroProps) {
       </div>
 
       <div className="space-y-1">
-        <p className="text-sm font-medium tracking-[0.3em] text-zinc-500">
+        <p className="text-sm font-medium tracking-[0.3em] text-ink-muted">
           #{dexNo(pokemon.id)}
         </p>
         <h1 className="text-3xl font-bold capitalize tracking-tight sm:text-5xl">
           {pokemon.name}
         </h1>
         {pokemon.species.genus && (
-          <p className="text-zinc-400">{pokemon.species.genus}</p>
+          <p className="text-ink-muted">{pokemon.species.genus}</p>
         )}
-        <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">
+        <p className="text-xs uppercase tracking-[0.2em] text-ink-muted">
           {genLabel(pokemon.id)}
         </p>
       </div>

--- a/src/components/detail/DetailPager.tsx
+++ b/src/components/detail/DetailPager.tsx
@@ -50,12 +50,12 @@ function PagerLink({
     >
       <Chevron
         direction={isPrev ? "left" : "right"}
-        className={`h-4 w-4 shrink-0 text-zinc-500 transition group-hover:text-zinc-200 ${
+        className={`h-4 w-4 shrink-0 text-ink-muted transition group-hover:text-zinc-200 ${
           isPrev ? "group-hover:-translate-x-0.5" : "group-hover:translate-x-0.5"
         }`}
       />
       <span className="flex min-w-0 items-baseline gap-1.5">
-        <span className="shrink-0 text-[11px] font-medium tracking-widest text-zinc-500">
+        <span className="shrink-0 text-[11px] font-medium tracking-widest text-ink-muted">
           #{dexNo(neighbor.id)}
         </span>
         <span className="min-w-0 truncate text-sm font-medium capitalize text-zinc-200">

--- a/src/components/detail/EvolutionChainView.tsx
+++ b/src/components/detail/EvolutionChainView.tsx
@@ -19,7 +19,7 @@ export function EvolutionChainView({
   accent,
 }: EvolutionChainViewProps) {
   if (stages.length <= 1) {
-    return <p className="text-zinc-400">This Pokémon does not evolve.</p>;
+    return <p className="text-ink-muted">This Pokémon does not evolve.</p>;
   }
 
   const maxStage = Math.max(...stages.map((s) => s.stage));
@@ -43,12 +43,12 @@ export function EvolutionChainView({
               <div className="flex flex-row items-center gap-1 sm:flex-col sm:gap-0.5">
                 <span
                   aria-hidden
-                  className="order-1 rotate-90 text-2xl leading-none text-zinc-600 sm:order-2 sm:rotate-0"
+                  className="order-1 rotate-90 text-2xl leading-none text-ink-muted sm:order-2 sm:rotate-0"
                 >
                   →
                 </span>
                 {linearCondition && (
-                  <span className="order-2 max-w-[120px] text-center text-[11px] leading-tight text-zinc-400 sm:order-1 sm:max-w-[90px]">
+                  <span className="order-2 max-w-[120px] text-center text-[11px] leading-tight text-ink-muted sm:order-1 sm:max-w-[90px]">
                     {linearCondition}
                   </span>
                 )}
@@ -85,14 +85,14 @@ export function EvolutionChainView({
                         blurDataURL="/images/placeholder.png"
                       />
                     </div>
-                    <span className="text-[10px] tracking-widest text-zinc-500">
+                    <span className="text-[10px] tracking-widest text-ink-muted">
                       #{dexNo(stage.id)}
                     </span>
                     <span className="text-sm font-medium capitalize">
                       {stage.name}
                     </span>
                     {branched && stage.condition && (
-                      <span className="text-[11px] leading-tight text-zinc-500">
+                      <span className="text-[11px] leading-tight text-ink-muted">
                         {stage.condition}
                       </span>
                     )}

--- a/src/components/detail/PokedexEntries.tsx
+++ b/src/components/detail/PokedexEntries.tsx
@@ -16,7 +16,7 @@ export function PokedexEntries({ entries }: { entries: FlavorEntry[] }) {
     <div className="space-y-3">
       {shown.map((entry) => (
         <div key={entry.generation} className="space-y-1">
-          <p className="text-[11px] font-medium uppercase tracking-[0.15em] text-zinc-500">
+          <p className="text-[11px] font-medium uppercase tracking-[0.15em] text-ink-muted">
             {entry.generationLabel} · {entry.version}
           </p>
           <p className="leading-relaxed text-zinc-300">

--- a/src/components/detail/StatBars.tsx
+++ b/src/components/detail/StatBars.tsx
@@ -37,7 +37,7 @@ export function StatBars({ stats }: { stats: PokemonStat[] }) {
         const filled = Math.round((stat.value / STAT_MAX) * SEGMENTS);
         return (
           <div key={stat.name} className="flex items-center gap-3">
-            <span className="w-14 shrink-0 text-xs font-medium text-zinc-400">
+            <span className="w-14 shrink-0 text-xs font-medium text-ink-muted">
               {STAT_LABELS[stat.name] ?? stat.name}
             </span>
 

--- a/src/components/detail/TypeMatchups.tsx
+++ b/src/components/detail/TypeMatchups.tsx
@@ -13,7 +13,7 @@ function Group({ title, items }: { title: string; items: TypeMatchup[] }) {
   if (items.length === 0) return null;
   return (
     <div className="space-y-2">
-      <h3 className="text-sm font-medium text-zinc-400">{title}</h3>
+      <h3 className="text-sm font-medium text-ink-muted">{title}</h3>
       <div className="flex flex-wrap gap-2">
         {items.map((matchup) => (
           <div key={matchup.type} className="flex items-center gap-1.5">

--- a/src/components/home/ControlDeck.tsx
+++ b/src/components/home/ControlDeck.tsx
@@ -26,7 +26,7 @@ export function ControlDeck({
     <div className="sticky z-9 top-[72px] rounded-2xl bg-slate-950/60 p-3 shadow-lg backdrop-blur-md sm:p-4">
       <div className="flex gap-2 flex-row items-center">
         <div className="relative flex-1">
-          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-ink-muted">
             🔍
           </span>
           <input
@@ -36,14 +36,14 @@ export function ControlDeck({
               onQueryChange(e.target.value)
             }
             placeholder={placeholder}
-            className="w-full rounded-xl border border-white/10 bg-white/5 py-2 pl-9 pr-3 text-sm text-white outline-hidden transition-colors placeholder:text-zinc-500 focus:border-white/30"
+            className="w-full rounded-xl border border-white/10 bg-white/5 py-2 pl-9 pr-3 text-sm text-white outline-hidden transition-colors placeholder:text-ink-muted focus:border-white/30"
           />
         </div>
 
         <div className="flex items-center gap-2">
           <label
             htmlFor="sort"
-            className="hidden sm:block text-xs tracking-wider text-zinc-500"
+            className="hidden sm:block text-xs tracking-wider text-ink-muted"
           >
             Sort
           </label>
@@ -67,7 +67,7 @@ export function ControlDeck({
       </div>
 
       <div className="mt-2 flex items-center gap-2">
-        <p className="text-xs text-zinc-500">{resultCount} results</p>
+        <p className="text-xs text-ink-muted">{resultCount} results</p>
         {isLoading && (
           <span
             aria-hidden

--- a/src/components/home/PokedexBrowser.tsx
+++ b/src/components/home/PokedexBrowser.tsx
@@ -56,7 +56,7 @@ export function PokedexBrowser({ initial }: PokedexBrowserProps) {
       </div>
 
       {isEmpty && (
-        <p className="py-8 text-center text-zinc-500">
+        <p className="py-8 text-center text-ink-muted">
           {query ? `No Pokémon match “${query}”.` : "Nothing to show."}
         </p>
       )}

--- a/src/components/home/PokemonRow.tsx
+++ b/src/components/home/PokemonRow.tsx
@@ -52,13 +52,13 @@ function PokemonRowComponent({ pokemon }: PokemonRowProps) {
 
       {/* Number · name · generation */}
       <div className="z-10 flex min-w-0 flex-1 flex-col gap-1">
-        <span className="text-xs font-medium tracking-[0.2em] text-zinc-500">
+        <span className="text-xs font-medium tracking-[0.2em] text-ink-muted">
           #{dex}
         </span>
         <h2 className="truncate text-lg font-semibold capitalize tracking-tight">
           {pokemon.name}
         </h2>
-        <p className="text-xs text-zinc-400">{genLabel(pokemon.id)}</p>
+        <p className="text-xs text-ink-muted">{genLabel(pokemon.id)}</p>
       </div>
 
       {/* Type chips — centered in the card (hidden on small screens) */}
@@ -99,21 +99,21 @@ export function PokemonRowSkeleton({
 
       <div className="z-10 flex min-w-0 flex-1 flex-col gap-1">
         {dex ? (
-          <span className="text-xs font-medium tracking-[0.2em] text-zinc-500">
+          <span className="text-xs font-medium tracking-[0.2em] text-ink-muted">
             #{dex}
           </span>
         ) : (
           <span className="h-3 w-10 animate-pulse rounded bg-white/10" />
         )}
         {name ? (
-          <h2 className="truncate text-lg font-semibold capitalize tracking-tight text-zinc-400">
+          <h2 className="truncate text-lg font-semibold capitalize tracking-tight text-ink-muted">
             {name}
           </h2>
         ) : (
           <span className="h-5 w-32 animate-pulse rounded bg-white/10" />
         )}
         {id != null ? (
-          <p className="text-xs text-zinc-600">{genLabel(id)}</p>
+          <p className="text-xs text-ink-muted">{genLabel(id)}</p>
         ) : (
           <span className="h-3 w-20 animate-pulse rounded bg-white/10" />
         )}


### PR DESCRIPTION
Make secondary text more readable across page, still indicating that it's sub text not a gray text that hard to read